### PR TITLE
Add personal portfolio website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# My-Life
+# Personal Website
+
+This repository contains the source code for Israel Oladeji Olaniyi's personal website. It highlights education, experience, projects, and skills.
+
+## Running locally
+
+Open `index.html` directly in a browser or serve the directory:
+
+```
+python3 -m http.server
+```
+
+Then visit <http://localhost:8000>.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Portfolio of Israel Oladeji Olaniyi showcasing education, experience, projects, and skills.">
+    <title>Israel Oladeji Olaniyi</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>Israel Oladeji Olaniyi</h1>
+    <nav>
+      <ul>
+        <li><a href="#about">About</a></li>
+        <li><a href="#education">Education</a></li>
+        <li><a href="#experience">Experience</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#skills">Skills</a></li>
+      </ul>
+    </nav>
+      <button id="theme-toggle" type="button" aria-label="Toggle dark theme">Toggle Theme</button>
+    </header>
+    <main>
+    <section id="about">
+    <h2>About</h2>
+    <p>Mobile app developer and AI enthusiast passionate about building tools that improve lives.</p>
+    <ul class="contact">
+      <li>Email: <a href="mailto:triygoc@icloud.com">triygoc@icloud.com</a></li>
+      <li>Phone: <a href="tel:+14632501298">463-250-1298</a></li>
+        <li><a href="https://linkedin.com/in/israel-oladeji-47a954238" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+        <li><a href="https://github.com/Ca3de" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+      </ul>
+    </section>
+
+  <section id="education">
+    <h2>Education</h2>
+    <h3>Purdue University Indianapolis (PUI)</h3>
+    <p><strong>B.S. in Computer Science, Minor in Mathematics</strong> — Expected May 2025</p>
+    <p>GPA: 3.33 | Dean’s List, Spring 2023</p>
+    <p>Relevant Coursework: Deep Learning, Natural Language Processing, Data Science, Biometric Computing, Numerical Methods, Digital Forensics, Game Design & Development, Fundamentals of Computing Theory, Data Structures, Computer Architecture, Operating Systems, Software Engineering Principles, Multivariate Calculus, Multidimensional Math, Linear Algebra, Mechanics, Microbiology</p>
+  </section>
+
+  <section id="experience">
+    <h2>Experience</h2>
+    <article>
+      <h3>All Saints Anglican Church (All Saints Online)</h3>
+      <p><em>Mobile App Developer</em> — May 2023 – Present | Indianapolis, IN</p>
+      <ul>
+        <li>Designed and launched a cross-platform mobile app published on the Apple App Store and Google Play Store.</li>
+        <li>Solely developed the app end-to-end from requirements gathering to deployment and maintenance.</li>
+        <li>Built a Firebase-powered backend with secure authentication, database management, and cloud storage integration.</li>
+        <li>Implemented real-time chat, event scheduling, and community engagement tools tailored to client operations.</li>
+      </ul>
+    </article>
+    <article>
+      <h3>Purdue University Indianapolis</h3>
+      <p><em>AI Research Intern</em> — Jan 2024 – May 2024 | Indianapolis, IN</p>
+      <ul>
+        <li>Developed an ensemble learning framework combining Naive Bayes and Multi-Layer Perceptron models, improving accuracy by 10%.</li>
+        <li>Conducted research on model interpretability and performance benchmarking.</li>
+        <li>Documented findings in technical reports and presented results to faculty and peers.</li>
+      </ul>
+    </article>
+    <article>
+      <h3>International Game Jam</h3>
+      <p><em>Game Development Intern</em> — Nov 2023 | Remote</p>
+      <ul>
+        <li>Collaborated with a multidisciplinary team to design and publish a puzzle platformer titled <em>Missing Limbs</em>.</li>
+        <li>Programmed core gameplay mechanics in C# using Unity.</li>
+        <li>Contributed to UI/UX design, debugging, and playtesting to deliver a functional prototype within 48 hours.</li>
+      </ul>
+    </article>
+    <article>
+      <h3>Networks Connect</h3>
+      <p><em>Technical Recruitment & Process Optimization Intern</em> — Jan 2024 – Apr 2024 | Indianapolis, IN</p>
+      <ul>
+        <li>Revamped candidate-selection workflow, reducing interview scheduling time by 75%.</li>
+        <li>Automated data-entry and reporting tasks, improving accuracy by 90%.</li>
+        <li>Streamlined communication and documentation across recruitment pipelines.</li>
+      </ul>
+    </article>
+  </section>
+
+  <section id="projects">
+    <h2>Projects</h2>
+    <article>
+      <h3>De-Cove – AI-Powered Study Companion</h3>
+      <p><em>Flutter | Firebase | Dart</em></p>
+      <ul>
+        <li>Designed an AI-powered mobile app combining tutoring, ebook reading, note-taking, music for focus, and real-time chat.</li>
+        <li>Built on Firebase with authentication, cloud storage, and push notifications.</li>
+        <li>Developed bookmarking and productivity features for personalized study flows.</li>
+      </ul>
+    </article>
+    <article>
+      <h3>Loch – Social Media for Authors & Readers</h3>
+      <p><em>Swift | Kotlin | Go | Python | Java | Docker</em></p>
+      <ul>
+        <li>Developing a dual-platform social media application designed specifically for authors and readers.</li>
+        <li>Building a microservices backend with Go, Python, and Java, containerized in Docker.</li>
+        <li>Implementing secure user authentication, real-time feeds, and content-sharing features.</li>
+      </ul>
+    </article>
+  </section>
+
+    <section id="skills">
+      <h2>Skills</h2>
+      <ul>
+        <li><strong>Technical Skills:</strong> Mobile App Development (iOS/Android), AI/ML Model Development, Backend Architecture, Cloud Integration, Game Development, Database Design, API Development</li>
+        <li><strong>Software & Tools:</strong> AWS, GCP/Vertex AI, Firebase, Docker, Git/GitHub, Unity, Linux/Unix, CI/CD Pipelines</li>
+        <li><strong>Programming Languages:</strong> Python, Java, C, C++, C#, JavaScript, TypeScript, Swift, Dart, Kotlin, HTML, CSS, SQL</li>
+        <li><strong>Frameworks & Libraries:</strong> Flutter, React Native, Node.js, TensorFlow, PyTorch, scikit-learn, Pandas, NumPy</li>
+        <li><strong>Soft Skills:</strong> Leadership, Team Mentorship, Communication, Problem-Solving, Process Optimization, Analytical Thinking, Collaboration</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; <span id="year"></span> Israel Oladeji Olaniyi</p>
+  </footer>
+
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,7 @@
+document.getElementById('year').textContent = new Date().getFullYear();
+
+const toggle = document.getElementById('theme-toggle');
+toggle.addEventListener('click', () => {
+  const dark = document.body.classList.toggle('dark');
+  toggle.setAttribute('aria-pressed', dark);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,73 @@
+:root {
+  --bg-color: #fdfdfd;
+  --text-color: #222;
+  --accent-color: #3f51b5;
+}
+
+body.dark {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --accent-color: #90caf9;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+  line-height: 1.6;
+}
+
+header {
+  background: var(--accent-color);
+  color: #fff;
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  }
+
+#theme-toggle {
+  background: #fff;
+  color: var(--accent-color);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+body.dark #theme-toggle {
+  background: var(--text-color);
+  color: var(--bg-color);
+}
+
+nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 1rem;
+}
+
+nav a {
+  color: #fff;
+  text-decoration: none;
+}
+
+section {
+  padding: 2rem;
+  max-width: 900px;
+  margin: auto;
+}
+
+.contact li {
+  margin-bottom: 0.5rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: var(--accent-color);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- Improve semantics and accessibility of the portfolio site with a meta description, main content wrapper, and secure external links
- Enhance theme toggle with ARIA support and matching styles for light/dark modes
- Expand README with instructions for running the site locally

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c77ebfc6748329952c7f6f7e9908f0