### PR TITLE
Refresh portfolio hero and section layouts

### DIFF
--- a/assets/israel-oladeji-olaniyi-resume.pdf
+++ b/assets/israel-oladeji-olaniyi-resume.pdf
@@ -1,0 +1,32 @@
+%PDF-1.1
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 66 >>
+stream
+BT /F1 18 Tf 36 200 Td (Resume available upon request.) Tj 0 -24 Td (Updated version coming soon.) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000118 00000 n 
+0000000290 00000 n 
+0000000423 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+513
+%%EOF

--- a/index.html
+++ b/index.html
@@ -7,117 +7,165 @@
     <title>Israel Oladeji Olaniyi</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css">
-  <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-  <header>
-    <h1>Israel Oladeji Olaniyi</h1>
-    <p class="tagline">Mobile App Developer &amp; AI Enthusiast</p>
-    <nav>
-      <ul>
-        <li><a href="#about">About</a></li>
-        <li><a href="#education">Education</a></li>
-        <li><a href="#experience">Experience</a></li>
-        <li><a href="#projects">Projects</a></li>
-        <li><a href="#skills">Skills</a></li>
-      </ul>
-    </nav>
-      <button id="theme-toggle" type="button" aria-label="Toggle dark theme">Toggle Theme</button>
-    </header>
+  <header class="site-header" id="top">
+    <div class="site-shell">
+      <div class="top-bar">
+        <a class="brand" href="#top">IOO</a>
+        <nav class="site-nav" aria-label="Primary">
+          <ul>
+            <li><a href="#about">About</a></li>
+            <li><a href="#education">Education</a></li>
+            <li><a href="#experience">Experience</a></li>
+            <li><a href="#projects">Projects</a></li>
+            <li><a href="#skills">Skills</a></li>
+          </ul>
+        </nav>
+        <button id="theme-toggle" type="button" aria-label="Toggle dark theme">Toggle Theme</button>
+      </div>
+      <div class="hero">
+        <div class="hero-content">
+          <h1>Israel Oladeji Olaniyi</h1>
+          <p class="tagline">Mobile App Developer &amp; AI Enthusiast</p>
+          <p class="summary">I build human-centered mobile and AI experiences that blend elegant design with reliable engineering. My passion lies in translating complex ideas into products that empower communities and businesses alike.</p>
+          <div class="hero-actions">
+            <a class="btn primary" href="assets/israel-oladeji-olaniyi-resume.pdf" download>Download Résumé</a>
+            <a class="btn secondary" href="mailto:triygoc@icloud.com">Contact Me</a>
+          </div>
+        </div>
+        <figure class="hero-media" aria-hidden="true">
+          <div class="portrait"></div>
+        </figure>
+      </div>
+    </div>
+  </header>
     <main>
-    <section id="about">
-    <h2>About</h2>
-    <p>Mobile app developer and AI enthusiast passionate about building tools that improve lives.</p>
-    <ul class="contact">
-      <li>Email: <a href="mailto:triygoc@icloud.com">triygoc@icloud.com</a></li>
-      <li>Phone: <a href="tel:+14632501298">463-250-1298</a></li>
-        <li><a href="https://linkedin.com/in/israel-oladeji-47a954238" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
-        <li><a href="https://github.com/Ca3de" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-      </ul>
-    </section>
+      <section id="about" class="section">
+        <div class="section-shell" data-icon="👋">
+          <div class="section-header">
+            <h2>About</h2>
+            <p class="section-subtitle">Mobile app developer and AI enthusiast passionate about building tools that improve lives.</p>
+          </div>
+          <ul class="contact-list">
+            <li><span>Email</span> <a href="mailto:triygoc@icloud.com">triygoc@icloud.com</a></li>
+            <li><span>Phone</span> <a href="tel:+14632501298">463-250-1298</a></li>
+            <li><span>LinkedIn</span> <a href="https://linkedin.com/in/israel-oladeji-47a954238" target="_blank" rel="noopener noreferrer">/israel-oladeji-47a954238</a></li>
+            <li><span>GitHub</span> <a href="https://github.com/Ca3de" target="_blank" rel="noopener noreferrer">@Ca3de</a></li>
+          </ul>
+        </div>
+      </section>
 
-  <section id="education">
-    <h2>Education</h2>
-    <h3>Purdue University Indianapolis (PUI)</h3>
-    <p><strong>B.S. in Computer Science, Minor in Mathematics</strong> — Expected May 2025</p>
-    <p>GPA: 3.33 | Dean’s List, Spring 2023</p>
-    <p>Relevant Coursework: Deep Learning, Natural Language Processing, Data Science, Biometric Computing, Numerical Methods, Digital Forensics, Game Design & Development, Fundamentals of Computing Theory, Data Structures, Computer Architecture, Operating Systems, Software Engineering Principles, Multivariate Calculus, Multidimensional Math, Linear Algebra, Mechanics, Microbiology</p>
-  </section>
+      <section id="education" class="section accent-band">
+        <div class="section-shell" data-icon="🎓">
+          <div class="section-header">
+            <h2>Education</h2>
+            <p class="section-subtitle">Academic foundation in computer science and mathematics.</p>
+          </div>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Purdue University Indianapolis (PUI)</h3>
+              <p><strong>B.S. in Computer Science, Minor in Mathematics</strong> — Expected May 2025</p>
+              <p>GPA: 3.33 | Dean’s List, Spring 2023</p>
+              <p class="meta">Relevant Coursework: Deep Learning, Natural Language Processing, Data Science, Biometric Computing, Numerical Methods, Digital Forensics, Game Design &amp; Development, Fundamentals of Computing Theory, Data Structures, Computer Architecture, Operating Systems, Software Engineering Principles, Multivariate Calculus, Multidimensional Math, Linear Algebra, Mechanics, Microbiology</p>
+            </article>
+          </div>
+        </div>
+      </section>
 
-  <section id="experience">
-    <h2>Experience</h2>
-    <article>
-      <h3>All Saints Anglican Church (All Saints Online)</h3>
-      <p><em>Mobile App Developer</em> — May 2023 – Present | Indianapolis, IN</p>
-      <ul>
-        <li>Designed and launched a cross-platform mobile app published on the Apple App Store and Google Play Store.</li>
-        <li>Solely developed the app end-to-end from requirements gathering to deployment and maintenance.</li>
-        <li>Built a Firebase-powered backend with secure authentication, database management, and cloud storage integration.</li>
-        <li>Implemented real-time chat, event scheduling, and community engagement tools tailored to client operations.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>Purdue University Indianapolis</h3>
-      <p><em>AI Research Intern</em> — Jan 2024 – May 2024 | Indianapolis, IN</p>
-      <ul>
-        <li>Developed an ensemble learning framework combining Naive Bayes and Multi-Layer Perceptron models, improving accuracy by 10%.</li>
-        <li>Conducted research on model interpretability and performance benchmarking.</li>
-        <li>Documented findings in technical reports and presented results to faculty and peers.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>International Game Jam</h3>
-      <p><em>Game Development Intern</em> — Nov 2023 | Remote</p>
-      <ul>
-        <li>Collaborated with a multidisciplinary team to design and publish a puzzle platformer titled <em>Missing Limbs</em>.</li>
-        <li>Programmed core gameplay mechanics in C# using Unity.</li>
-        <li>Contributed to UI/UX design, debugging, and playtesting to deliver a functional prototype within 48 hours.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>Networks Connect</h3>
-      <p><em>Technical Recruitment & Process Optimization Intern</em> — Jan 2024 – Apr 2024 | Indianapolis, IN</p>
-      <ul>
-        <li>Revamped candidate-selection workflow, reducing interview scheduling time by 75%.</li>
-        <li>Automated data-entry and reporting tasks, improving accuracy by 90%.</li>
-        <li>Streamlined communication and documentation across recruitment pipelines.</li>
-      </ul>
-    </article>
-  </section>
+      <section id="experience" class="section">
+        <div class="section-shell" data-icon="💼">
+          <div class="section-header">
+            <h2>Experience</h2>
+            <p class="section-subtitle">Recent roles spanning product development, research, and process optimization.</p>
+          </div>
+          <div class="card-grid">
+            <article class="card">
+              <h3>All Saints Anglican Church (All Saints Online)</h3>
+              <p class="meta"><em>Mobile App Developer</em> — May 2023 – Present | Indianapolis, IN</p>
+              <ul>
+                <li>Designed and launched a cross-platform mobile app published on the Apple App Store and Google Play Store.</li>
+                <li>Solely developed the app end-to-end from requirements gathering to deployment and maintenance.</li>
+                <li>Built a Firebase-powered backend with secure authentication, database management, and cloud storage integration.</li>
+                <li>Implemented real-time chat, event scheduling, and community engagement tools tailored to client operations.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Purdue University Indianapolis</h3>
+              <p class="meta"><em>AI Research Intern</em> — Jan 2024 – May 2024 | Indianapolis, IN</p>
+              <ul>
+                <li>Developed an ensemble learning framework combining Naive Bayes and Multi-Layer Perceptron models, improving accuracy by 10%.</li>
+                <li>Conducted research on model interpretability and performance benchmarking.</li>
+                <li>Documented findings in technical reports and presented results to faculty and peers.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>International Game Jam</h3>
+              <p class="meta"><em>Game Development Intern</em> — Nov 2023 | Remote</p>
+              <ul>
+                <li>Collaborated with a multidisciplinary team to design and publish a puzzle platformer titled <em>Missing Limbs</em>.</li>
+                <li>Programmed core gameplay mechanics in C# using Unity.</li>
+                <li>Contributed to UI/UX design, debugging, and playtesting to deliver a functional prototype within 48 hours.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Networks Connect</h3>
+              <p class="meta"><em>Technical Recruitment &amp; Process Optimization Intern</em> — Jan 2024 – Apr 2024 | Indianapolis, IN</p>
+              <ul>
+                <li>Revamped candidate-selection workflow, reducing interview scheduling time by 75%.</li>
+                <li>Automated data-entry and reporting tasks, improving accuracy by 90%.</li>
+                <li>Streamlined communication and documentation across recruitment pipelines.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
 
-  <section id="projects">
-    <h2>Projects</h2>
-    <article>
-      <h3>De-Cove – AI-Powered Study Companion</h3>
-      <p><em>Flutter | Firebase | Dart</em></p>
-      <ul>
-        <li>Designed an AI-powered mobile app combining tutoring, ebook reading, note-taking, music for focus, and real-time chat.</li>
-        <li>Built on Firebase with authentication, cloud storage, and push notifications.</li>
-        <li>Developed bookmarking and productivity features for personalized study flows.</li>
-      </ul>
-    </article>
-    <article>
-      <h3>Loch – Social Media for Authors & Readers</h3>
-      <p><em>Swift | Kotlin | Go | Python | Java | Docker</em></p>
-      <ul>
-        <li>Developing a dual-platform social media application designed specifically for authors and readers.</li>
-        <li>Building a microservices backend with Go, Python, and Java, containerized in Docker.</li>
-        <li>Implementing secure user authentication, real-time feeds, and content-sharing features.</li>
-      </ul>
-    </article>
-  </section>
+      <section id="projects" class="section accent-band">
+        <div class="section-shell" data-icon="🚀">
+          <div class="section-header">
+            <h2>Projects</h2>
+            <p class="section-subtitle">Select products showcasing user-focused delivery and technical range.</p>
+          </div>
+          <div class="card-grid">
+            <article class="card">
+              <h3>De-Cove – AI-Powered Study Companion</h3>
+              <p class="meta"><em>Flutter | Firebase | Dart</em></p>
+              <ul>
+                <li>Designed an AI-powered mobile app combining tutoring, ebook reading, note-taking, music for focus, and real-time chat.</li>
+                <li>Built on Firebase with authentication, cloud storage, and push notifications.</li>
+                <li>Developed bookmarking and productivity features for personalized study flows.</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Loch – Social Media for Authors &amp; Readers</h3>
+              <p class="meta"><em>Swift | Kotlin | Go | Python | Java | Docker</em></p>
+              <ul>
+                <li>Developing a dual-platform social media application designed specifically for authors and readers.</li>
+                <li>Building a microservices backend with Go, Python, and Java, containerized in Docker.</li>
+                <li>Implementing secure user authentication, real-time feeds, and content-sharing features.</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
 
-    <section id="skills">
-      <h2>Skills</h2>
-      <ul>
-        <li><strong>Technical Skills:</strong> Mobile App Development (iOS/Android), AI/ML Model Development, Backend Architecture, Cloud Integration, Game Development, Database Design, API Development</li>
-        <li><strong>Software & Tools:</strong> AWS, GCP/Vertex AI, Firebase, Docker, Git/GitHub, Unity, Linux/Unix, CI/CD Pipelines</li>
-        <li><strong>Programming Languages:</strong> Python, Java, C, C++, C#, JavaScript, TypeScript, Swift, Dart, Kotlin, HTML, CSS, SQL</li>
-        <li><strong>Frameworks & Libraries:</strong> Flutter, React Native, Node.js, TensorFlow, PyTorch, scikit-learn, Pandas, NumPy</li>
-        <li><strong>Soft Skills:</strong> Leadership, Team Mentorship, Communication, Problem-Solving, Process Optimization, Analytical Thinking, Collaboration</li>
-      </ul>
-    </section>
-  </main>
+      <section id="skills" class="section">
+        <div class="section-shell" data-icon="🛠️">
+          <div class="section-header">
+            <h2>Skills</h2>
+            <p class="section-subtitle">Tools and capabilities that bring ideas to life.</p>
+          </div>
+          <ul class="skill-list">
+            <li><strong>Technical Skills:</strong> Mobile App Development (iOS/Android), AI/ML Model Development, Backend Architecture, Cloud Integration, Game Development, Database Design, API Development</li>
+            <li><strong>Software &amp; Tools:</strong> AWS, GCP/Vertex AI, Firebase, Docker, Git/GitHub, Unity, Linux/Unix, CI/CD Pipelines</li>
+            <li><strong>Programming Languages:</strong> Python, Java, C, C++, C#, JavaScript, TypeScript, Swift, Dart, Kotlin, HTML, CSS, SQL</li>
+            <li><strong>Frameworks &amp; Libraries:</strong> Flutter, React Native, Node.js, TensorFlow, PyTorch, scikit-learn, Pandas, NumPy</li>
+            <li><strong>Soft Skills:</strong> Leadership, Team Mentorship, Communication, Problem-Solving, Process Optimization, Analytical Thinking, Collaboration</li>
+          </ul>
+        </div>
+      </section>
+    </main>
 
   <footer>
     <p>&copy; <span id="year"></span> Israel Oladeji Olaniyi</p>

--- a/styles.css
+++ b/styles.css
@@ -1,20 +1,53 @@
+* {
+  box-sizing: border-box;
+}
+
 :root {
-  --bg-color: #f7f9fc;
-  --text-color: #222;
+  --font-family-base: 'Poppins', sans-serif;
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-size-xs: 0.85rem;
+  --font-size-sm: clamp(0.95rem, 0.25vw + 0.9rem, 1.05rem);
+  --font-size-md: clamp(1.05rem, 0.3vw + 1rem, 1.2rem);
+  --font-size-lg: clamp(1.5rem, 1.4vw + 1.1rem, 2.1rem);
+  --font-size-xl: clamp(2.2rem, 2.5vw + 1.8rem, 3.1rem);
+  --space-2xs: 0.5rem;
+  --space-xs: 0.75rem;
+  --space-sm: 1rem;
+  --space-md: 1.5rem;
+  --space-lg: 2rem;
+  --space-xl: 3rem;
+  --space-2xl: 4rem;
+  --radius-sm: 0.5rem;
+  --radius-md: 0.8rem;
+  --radius-lg: 1.25rem;
+  --shadow-soft: 0 18px 45px rgba(63, 81, 181, 0.12);
+  --shadow-hero: 0 30px 60px rgba(15, 23, 42, 0.25);
+  --max-width: 1100px;
+  --bg-color: #f6f7fb;
+  --surface-color: #ffffff;
+  --surface-alt: #eef1ff;
+  --text-color: #1a1c1f;
+  --text-muted: #4b5563;
   --accent-color: #3f51b5;
-  --card-bg: #fff;
-  --divider-color: rgba(0,0,0,0.1);
-  --bg-color: #fdfdfd;
-  --text-color: #222;
-  --accent-color: #3f51b5;
+  --accent-strong: #2a3eb1;
+  --accent-soft: rgba(63, 81, 181, 0.12);
+  --divider-color: rgba(30, 41, 59, 0.1);
 }
 
 body.dark {
-  --bg-color: #121212;
-  --text-color: #e0e0e0;
-  --accent-color: #90caf9;
-  --card-bg: #1e1e1e;
-  --divider-color: rgba(255,255,255,0.1);
+  --bg-color: #0f172a;
+  --surface-color: #131f3a;
+  --surface-alt: #182750;
+  --text-color: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent-color: #8ab4ff;
+  --accent-strong: #c3d7ff;
+  --accent-soft: rgba(138, 180, 255, 0.16);
+  --divider-color: rgba(148, 163, 184, 0.25);
+  --shadow-soft: 0 18px 45px rgba(12, 20, 35, 0.55);
+  --shadow-hero: 0 30px 60px rgba(12, 20, 35, 0.6);
 }
 
 html {
@@ -22,146 +55,472 @@ html {
 }
 
 body {
-  font-family: 'Poppins', sans-serif;
-}
-
-body {
-  font-family: Arial, sans-serif;
   margin: 0;
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-regular);
   background: var(--bg-color);
   color: var(--text-color);
-  line-height: 1.6;
-  transition: background 0.3s, color 0.3s;
+  line-height: 1.7;
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-header {
-  background: linear-gradient(135deg, var(--accent-color), #6573c3);
-  color: #fff;
-  padding: 3rem 1rem 2rem;
-  text-align: center;
-}
-
-nav ul {
-  list-style: none;
-  padding: 0;
-  margin: 1rem 0 0;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 1.5rem;
-}
-
-nav a {
-  color: #fff;
+a {
+  color: var(--accent-color);
   text-decoration: none;
-  font-weight: 600;
+  transition: color 0.2s ease;
 }
 
-nav a:hover {
-  text-decoration: underline;
+a:hover,
+a:focus {
+  color: var(--accent-strong);
 }
 
-.tagline {
-  margin-top: 0.5rem;
-  font-weight: 300;
+h1,
+h2,
+h3 {
+  font-family: var(--font-family-base);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1.2;
+  margin: 0 0 var(--space-sm);
 }
 
-#theme-toggle {
-  margin-top: 1rem;
+h1 {
+  font-size: var(--font-size-xl);
 }
 
-header {
-  background: var(--accent-color);
+h2 {
+  font-size: var(--font-size-lg);
+}
+
+h3 {
+  font-size: var(--font-size-md);
+}
+
+p {
+  margin: 0 0 var(--space-sm);
+  font-size: var(--font-size-sm);
+  color: var(--text-muted);
+}
+
+main {
+  padding-bottom: var(--space-2xl);
+}
+
+.site-shell {
+  width: min(var(--max-width), calc(100% - 2 * var(--space-lg)));
+  margin: 0 auto;
+}
+
+.site-header {
+  background: linear-gradient(135deg, #283593, var(--accent-color));
   color: #fff;
-  padding: 1rem;
+  padding: var(--space-lg) 0 var(--space-2xl);
+  position: relative;
+  overflow: hidden;
+}
+
+.site-header::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 180px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.12), transparent 65%);
+  pointer-events: none;
+}
+
+.top-bar {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  }
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-lg);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: inherit;
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand:hover,
+.brand:focus {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+.site-nav ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav a {
+  color: inherit;
+  font-weight: var(--font-weight-medium);
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(4px);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+}
 
 #theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
   background: #fff;
-  color: var(--accent-color);
+  color: #1f2937;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
+  border-radius: 999px;
+  padding: 0.55rem 1.1rem;
+  font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, color 0.3s ease;
+}
+
+#theme-toggle:hover,
+#theme-toggle:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 28px rgba(15, 23, 42, 0.25);
 }
 
 body.dark #theme-toggle {
-  background: var(--text-color);
-  color: var(--bg-color);
+  background: rgba(15, 23, 42, 0.75);
+  color: #f8fafc;
+  box-shadow: 0 18px 28px rgba(12, 20, 35, 0.35);
 }
 
-section {
-  padding: 2rem 1rem;
-  max-width: 900px;
-  margin: 2rem auto;
-  background: var(--card-bg);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-  transition: background 0.3s, color 0.3s;
-}
-
-section h2 {
-  margin-top: 0;
-  display: inline-block;
-  border-bottom: 2px solid var(--accent-color);
-  padding-bottom: 0.25rem;
-  margin-bottom: 1rem;
-}
-
-article {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--divider-color);
-}
-
-article:last-child {
-  margin-bottom: 0;
-  border-bottom: none;
-}
-
-.contact {
-  list-style: none;
-  padding: 0;
-nav ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.hero {
   display: flex;
-  gap: 1rem;
+  flex-direction: column;
+  gap: var(--space-lg);
 }
 
-nav a {
-  color: #fff;
+.hero-content {
+  flex: 1;
+}
+
+.hero-content .tagline {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.hero-content .summary {
+  color: rgba(255, 255, 255, 0.78);
+  max-width: 45ch;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-top: var(--space-sm);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2xs);
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: var(--font-weight-semibold);
   text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.3s ease, color 0.3s ease;
 }
 
-section {
-  padding: 2rem;
-  max-width: 900px;
-  margin: auto;
+.btn.primary {
+  background: #fff;
+  color: #1f2937;
+  box-shadow: var(--shadow-hero);
 }
 
-.contact li {
-  margin-bottom: 0.5rem;
+.btn.primary:hover,
+.btn.primary:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 35px 60px rgba(15, 23, 42, 0.3);
+}
+
+.btn.secondary {
+  background: transparent;
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+}
+
+.btn.secondary:hover,
+.btn.secondary:focus {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-3px);
+}
+
+body.dark .btn.primary {
+  background: var(--accent-color);
+  color: #0b1223;
+}
+
+body.dark .btn.primary:hover,
+body.dark .btn.primary:focus {
+  box-shadow: 0 35px 60px rgba(12, 20, 35, 0.5);
+}
+
+body.dark .btn.secondary {
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+body.dark .btn.secondary:hover,
+body.dark .btn.secondary:focus {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.hero-media {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: center;
+}
+
+.portrait {
+  width: clamp(220px, 30vw, 320px);
+  aspect-ratio: 1 / 1;
+  border-radius: 45% 55% 50% 55%;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.15)),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0));
+  position: relative;
+  box-shadow: var(--shadow-hero);
+}
+
+.portrait::after {
+  content: "";
+  position: absolute;
+  inset: 12%;
+  border-radius: 42% 58% 50% 60%;
+  background: linear-gradient(135deg, rgba(40, 53, 147, 0.8), rgba(63, 81, 181, 0.6));
+}
+
+.section {
+  position: relative;
+  padding: var(--space-xl) 0;
+}
+
+.section-shell {
+  position: relative;
+  margin: 0 auto;
+  width: min(var(--max-width), calc(100% - 2 * var(--space-lg)));
+  background: var(--surface-color);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  border: 1px solid var(--divider-color);
+  box-shadow: var(--shadow-soft);
+  transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.section-shell::before {
+  content: attr(data-icon);
+  position: absolute;
+  top: -1.75rem;
+  left: var(--space-lg);
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-size: 1.45rem;
+  box-shadow: 0 15px 28px rgba(63, 81, 181, 0.2);
+}
+
+body.dark .section-shell::before {
+  box-shadow: 0 15px 28px rgba(12, 20, 35, 0.55);
+}
+
+.section.accent-band .section-shell {
+  background: linear-gradient(135deg, var(--surface-color), var(--surface-alt));
+}
+
+.section-header {
+  margin-bottom: var(--space-md);
+}
+
+.section-subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.contact-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-sm);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.contact-list span {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
+}
+
+.contact-list a {
+  font-weight: var(--font-weight-semibold);
+}
+
+.card-grid {
+  display: grid;
+  gap: var(--space-md);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: var(--surface-color);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  border: 1px solid var(--divider-color);
+  box-shadow: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.card:hover,
+.card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(63, 81, 181, 0.28);
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.15);
+}
+
+.card .meta {
+  color: var(--text-muted);
+  font-size: var(--font-size-xs);
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.card ul li {
+  font-size: var(--font-size-sm);
+  color: var(--text-color);
+}
+
+.card ul li::marker {
+  color: var(--accent-color);
+}
+
+.skill-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-sm);
+}
+
+.skill-list li {
+  background: var(--surface-alt);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  border: 1px solid var(--divider-color);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: var(--text-color);
+}
+
+.skill-list li:hover,
+.skill-list li:focus-within {
+  transform: translateY(-4px);
+  border-color: rgba(63, 81, 181, 0.28);
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
 }
 
 footer {
   text-align: center;
-  padding: 1rem;
-  background: var(--accent-color);
-  color: #fff;
+  padding: var(--space-md);
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  transition: background 0.3s ease, color 0.3s ease;
 }
 
-main a {
-  color: var(--accent-color);
-  text-decoration: none;
+body.dark footer {
+  background: #0b1223;
+  color: #94a3b8;
 }
 
-main a:hover {
-  text-decoration: underline;
+@media (min-width: 768px) {
+  .hero {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .hero-content {
+    max-width: 58%;
+  }
+}
+
+@media (max-width: 767px) {
+  .site-shell {
+    width: calc(100% - 2 * var(--space-sm));
+  }
+
+  .top-bar {
+    gap: var(--space-xs);
+  }
+
+  .site-nav ul {
+    justify-content: center;
+  }
+
+  #theme-toggle {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .section-shell::before {
+    left: var(--space-sm);
+  }
+}
+
+@media (max-width: 480px) {
+  .site-nav ul {
+    gap: var(--space-xs);
+  }
+
+  .site-nav a {
+    padding-inline: 0.75rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- rebuild the header into a hero layout with navigation, summary messaging, and resume/contact calls-to-action beside a decorative portrait treatment
- restructure the About, Education, Experience, Projects, and Skills sections into themed card grids with supporting subtitles, icons, and consistent spacing
- introduce a cohesive design system in CSS with typography/spacing scales, dark-mode aware accents, and provide a downloadable résumé placeholder asset

## Testing
- Manual - Viewed in browser (Playwright screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e46c3b1e948329a64d94fc85eb4a34