### PR TITLE
Clean up CSS theming and layout rules

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,10 +3,7 @@
   --text-color: #222;
   --accent-color: #3f51b5;
   --card-bg: #fff;
-  --divider-color: rgba(0,0,0,0.1);
-  --bg-color: #fdfdfd;
-  --text-color: #222;
-  --accent-color: #3f51b5;
+  --divider-color: rgba(0, 0, 0, 0.1);
 }
 
 body.dark {
@@ -23,10 +20,6 @@ html {
 
 body {
   font-family: 'Poppins', sans-serif;
-}
-
-body {
-  font-family: Arial, sans-serif;
   margin: 0;
   background: var(--bg-color);
   color: var(--text-color);
@@ -39,6 +32,10 @@ header {
   color: #fff;
   padding: 3rem 1rem 2rem;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
 }
 
 nav ul {
@@ -65,20 +62,6 @@ nav a:hover {
   margin-top: 0.5rem;
   font-weight: 300;
 }
-
-#theme-toggle {
-  margin-top: 1rem;
-}
-
-header {
-  background: var(--accent-color);
-  color: #fff;
-  padding: 1rem;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  }
 
 #theme-toggle {
   background: #fff;
@@ -127,23 +110,6 @@ article:last-child {
 .contact {
   list-style: none;
   padding: 0;
-nav ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  gap: 1rem;
-}
-
-nav a {
-  color: #fff;
-  text-decoration: none;
-}
-
-section {
-  padding: 2rem;
-  max-width: 900px;
-  margin: auto;
 }
 
 .contact li {


### PR DESCRIPTION
## Summary
- collapse duplicate CSS variable declarations and consolidate the base body typography styles
- merge the hero header rules into a single flex-based gradient block and keep navigation/button styling intact
- close the contact list styles and remove duplicate section/navigation rules for a cleaner stylesheet

## Testing
- python -m http.server 8000 (manual verification via browser_container)


------
https://chatgpt.com/codex/tasks/task_e_68e46c38d5848329926909bdf2146e8a