### PR TITLE
Fix cross-window bridge dedupe regression

### DIFF
--- a/script.js
+++ b/script.js
@@ -120,10 +120,13 @@ const createCrossWindowBridge = (() => {
     const listeners = new Set();
     const bridgeId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
     let channel = null;
+    let sequence = 0;
 
     const dispatch = (payload) => {
       if (!payload || payload.id === bridgeId) return;
-      const signature = `${payload.id}:${payload.timestamp}`;
+      const signature = `${payload.id}:${payload.timestamp}:${payload.type ?? ''}:${
+        payload.sequence ?? ''
+      }`;
       if (seen.has(signature)) return;
       seen.add(signature);
       if (seen.size > 2000) {
@@ -157,11 +160,13 @@ const createCrossWindowBridge = (() => {
     window.addEventListener('storage', storageHandler);
 
     const emit = (type, data, { flush = false } = {}) => {
+      sequence = (sequence + 1) % Number.MAX_SAFE_INTEGER;
       const payload = {
         id: bridgeId,
         type,
         data,
         timestamp: Date.now(),
+        sequence,
       };
 
       if (channel) {


### PR DESCRIPTION
## Summary
- add a per-bridge sequence counter to every emitted payload
- include the payload type and sequence in the duplicate filter signature so concurrent events are preserved

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68eef572619c8329bb8c97721b1e0d42